### PR TITLE
Back button CSS

### DIFF
--- a/blog/assets/css/custom.css
+++ b/blog/assets/css/custom.css
@@ -236,6 +236,7 @@ a.p10k-seg:active {
     position: relative;
     width: var(--p10k-arrow-w);
     flex-shrink: 0;
+    margin-right: -0.25px;
 }
 
 .back-btn__arrow::before {


### PR DESCRIPTION
Noticed my post back button had an ever so slightly visible gap in between the arrow and block elements. Adjusted pixel margin to remove this.