### PR TITLE
Git branch hover highlight

### DIFF
--- a/blog/assets/css/custom.css
+++ b/blog/assets/css/custom.css
@@ -222,6 +222,11 @@ a.p10k-seg:active {
 /* Branch dropdown (no arrow) */
 .p10k-branch-dropdown {
     position: relative;
+    cursor: pointer;
+}
+
+.p10k-branch-dropdown:hover {
+    background: color-mix(in srgb, var(--seg-bg) 75%, black);
 }
 
 .p10k-branch-select {


### PR DESCRIPTION
I noticed the git branch element didn't highlight on hover. Now it does.